### PR TITLE
Changing سبإ to سبأ

### DIFF
--- a/public/data/ar/34.json
+++ b/public/data/ar/34.json
@@ -1,1 +1,1 @@
-{"chapter":{"id":34,"revelationPlace":"makkah","revelationOrder":58,"bismillahPre":true,"nameSimple":"Saba","nameComplex":"Saba","nameArabic":"سبإ","versesCount":54,"pages":[428,434],"slug":{"slug":"saba","locale":"en"},"translatedName":{"languageName":"english","name":"Sheba"}}}
+{"chapter":{"id":34,"revelationPlace":"makkah","revelationOrder":58,"bismillahPre":true,"nameSimple":"Saba","nameComplex":"Saba","nameArabic":"سبأ","versesCount":54,"pages":[428,434],"slug":{"slug":"saba","locale":"en"},"translatedName":{"languageName":"english","name":"Sheba"}}}

--- a/public/data/bn/34.json
+++ b/public/data/bn/34.json
@@ -1,1 +1,1 @@
-{"chapter":{"id":34,"revelationPlace":"makkah","revelationOrder":58,"bismillahPre":true,"nameSimple":"Saba","nameComplex":"Saba","nameArabic":"سبإ","versesCount":54,"pages":[428,434],"slug":{"slug":"saba","locale":"en"},"translatedName":{"languageName":"bengali","name":"রানী সাবা/শেবা"}}}
+{"chapter":{"id":34,"revelationPlace":"makkah","revelationOrder":58,"bismillahPre":true,"nameSimple":"Saba","nameComplex":"Saba","nameArabic":"سبأ","versesCount":54,"pages":[428,434],"slug":{"slug":"saba","locale":"en"},"translatedName":{"languageName":"bengali","name":"রানী সাবা/শেবা"}}}

--- a/public/data/ur/34.json
+++ b/public/data/ur/34.json
@@ -1,1 +1,1 @@
-{"chapter":{"id":34,"revelationPlace":"makkah","revelationOrder":58,"bismillahPre":true,"nameSimple":"Saba","nameComplex":"Saba","nameArabic":"سبإ","versesCount":54,"pages":[428,434],"slug":{"slug":"saba","locale":"en"},"translatedName":{"languageName":"urdu","name":"سبا"}}}
+{"chapter":{"id":34,"revelationPlace":"makkah","revelationOrder":58,"bismillahPre":true,"nameSimple":"Saba","nameComplex":"Saba","nameArabic":"سبأ","versesCount":54,"pages":[428,434],"slug":{"slug":"saba","locale":"en"},"translatedName":{"languageName":"urdu","name":"سبا"}}}

--- a/public/data/zh/34.json
+++ b/public/data/zh/34.json
@@ -1,1 +1,1 @@
-{"chapter":{"id":34,"revelationPlace":"makkah","revelationOrder":58,"bismillahPre":true,"nameSimple":"Saba","nameComplex":"Saba","nameArabic":"سبإ","versesCount":54,"pages":[428,434],"slug":{"slug":"saba","locale":"en"},"translatedName":{"languageName":"chinese","name":"赛伯邑"}}}
+{"chapter":{"id":34,"revelationPlace":"makkah","revelationOrder":58,"bismillahPre":true,"nameSimple":"Saba","nameComplex":"Saba","nameArabic":"سبأ","versesCount":54,"pages":[428,434],"slug":{"slug":"saba","locale":"en"},"translatedName":{"languageName":"chinese","name":"赛伯邑"}}}


### PR DESCRIPTION
Hi there. Just noticed, while reading the quran. That the name of the suraah Sabaa سبأ in arabic, is written there as سبإ
which is wrong. 

Well i fixed a few. I haven't changed all the files that contain this vocab error, i am super busy right now, but I will do it for all files when i get time to do so.
Also in the front-end github, needs to be looked at.

Thanks  for your efforts.