### PR TITLE
Fix premade OG paths to return proper PNG content type

### DIFF
--- a/src/pages/api/og/about-the-quran/index.tsx
+++ b/src/pages/api/og/about-the-quran/index.tsx
@@ -21,5 +21,5 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   if (preMadeLocales[language.code]) return fetch(preMadeLocales[language.code]);
 
-  return fetch(new URL('/public/premade/og_about_en.png', import.meta.url),);
+  return fetch(new URL('/premade/og_about_en.png', req.url));
 }

--- a/src/pages/api/og/beyond-ramadan/index.tsx
+++ b/src/pages/api/og/beyond-ramadan/index.tsx
@@ -21,5 +21,5 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   if (preMadeLocales[language.code]) return fetch(preMadeLocales[language.code]);
 
-  return fetch(new URL('/public/premade/og_beyond_ramadan.png', import.meta.url),);
+  return fetch(new URL('/premade/og_beyond_ramadan.png', req.url));
 }

--- a/src/pages/api/og/calendar/index.tsx
+++ b/src/pages/api/og/calendar/index.tsx
@@ -21,5 +21,5 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   if (preMadeLocales[language.code]) return fetch(preMadeLocales[language.code]);
 
-  return fetch(new URL('/public/premade/og_calendar.png', import.meta.url),);
+  return fetch(new URL('/premade/og_calendar.png', req.url));
 }

--- a/src/pages/api/og/embed/index.tsx
+++ b/src/pages/api/og/embed/index.tsx
@@ -21,5 +21,5 @@ export default async function handler(req: NextRequest): Promise<Response> {
     return fetch(preMadeLocales[language.code]);
   }
 
-  return fetch(new URL('/public/premade/og_embed.png', import.meta.url));
+  return fetch(new URL('/premade/og_embed.png', req.url));
 }

--- a/src/pages/api/og/explore-answers/index.tsx
+++ b/src/pages/api/og/explore-answers/index.tsx
@@ -23,5 +23,5 @@ export default async function handler(req: NextRequest): Promise<Response> {
     return fetch(preMadeLocales[language.code]);
   }
 
-  return fetch(new URL('/public/premade/og_explore_answers.png', import.meta.url),);
+  return fetch(new URL('/premade/og_explore_answers.png', req.url));
 }

--- a/src/pages/api/og/learning-plans/index.tsx
+++ b/src/pages/api/og/learning-plans/index.tsx
@@ -23,5 +23,5 @@ export default async function handler(req: NextRequest): Promise<Response> {
     return fetch(preMadeLocales[language.code]);
   }
 
-  return fetch(new URL('/public/premade/og_learning_plans.png', import.meta.url),);
+  return fetch(new URL('/premade/og_learning_plans.png', req.url));
 }

--- a/src/pages/api/og/media/index.tsx
+++ b/src/pages/api/og/media/index.tsx
@@ -23,5 +23,5 @@ export default async function handler(req: NextRequest): Promise<Response> {
     return fetch(preMadeLocales[language.code]);
   }
 
-  return fetch(new URL('/public/premade/og_media.png', import.meta.url),);
+  return fetch(new URL('/premade/og_media.png', req.url));
 }

--- a/src/pages/api/og/preparing-for-ramadan/index.tsx
+++ b/src/pages/api/og/preparing-for-ramadan/index.tsx
@@ -23,5 +23,5 @@ export default async function handler(req: NextRequest): Promise<Response> {
     return fetch(preMadeLocales[language.code]);
   }
 
-  return fetch(new URL('/public/premade/og_preparing_for_ramadan.png', import.meta.url),);
+  return fetch(new URL('/premade/og_preparing_for_ramadan.png', req.url));
 }

--- a/src/pages/api/og/ramadan2026/index.tsx
+++ b/src/pages/api/og/ramadan2026/index.tsx
@@ -21,5 +21,5 @@ export default async function handler(req: NextRequest): Promise<Response> {
     return fetch(preMadeLocales[language.code]);
   }
 
-  return fetch(new URL('/public/premade/og_ramadan2026.png', import.meta.url));
+  return fetch(new URL('/premade/og_ramadan2026.png', req.url));
 }

--- a/src/pages/api/og/ramadanchallenge/index.tsx
+++ b/src/pages/api/og/ramadanchallenge/index.tsx
@@ -21,5 +21,5 @@ export default async function handler(req: NextRequest): Promise<Response> {
     return fetch(preMadeLocales[language.code]);
   }
 
-  return fetch(new URL('/public/premade/og_ramadanchallenge.png', import.meta.url));
+  return fetch(new URL('/premade/og_ramadanchallenge.png', req.url));
 }

--- a/src/pages/api/og/what-is-ramadan/index.tsx
+++ b/src/pages/api/og/what-is-ramadan/index.tsx
@@ -23,5 +23,5 @@ export default async function handler(req: NextRequest): Promise<Response> {
     return fetch(preMadeLocales[language.code]);
   }
 
-  return fetch(new URL('/public/premade/og_what_is_ramadan.png', import.meta.url),);
+  return fetch(new URL('/premade/og_what_is_ramadan.png', req.url));
 }

--- a/tests/og-images.spec.ts
+++ b/tests/og-images.spec.ts
@@ -233,6 +233,7 @@ test.describe("Calendar (/api/og/calendar)", () => {
   test("returns valid PNG", async ({ request }) => {
     const response = await request.get("/api/og/calendar");
     expect(response.status()).toBe(200);
+    expect(response.headers()["content-type"]).toContain("image/png");
 
     const body = await response.body();
     expect(isPng(body)).toBe(true);


### PR DESCRIPTION
## Summary
- switch static OG handlers to fetch premade assets from `/premade/...` using `req.url`
- remove `/public/...` + `import.meta.url` usage in static OG handlers
- add a regression check asserting `content-type` includes `image/png` for `/api/og/calendar`

## Why
`/api/og/calendar` was returning a non-PNG content type due to how the premade image URL was built. Using Next's public asset URL path keeps the response content type correct.

## Validation
- `BASE_URL=http://localhost:3000 pnpm exec playwright test tests/og-images.spec.ts -g "Calendar \\(/api/og/calendar\\)" --project=chromium`
- `curl -I http://localhost:3000/api/og/calendar` returns `content-type: image/png`
