### PR TITLE
Reinstate static OG MIME fix safely

### DIFF
--- a/src/lib/premadeOpenGraph.ts
+++ b/src/lib/premadeOpenGraph.ts
@@ -44,7 +44,7 @@ const fetchFallbackPng = async (url: URL): Promise<Response> => {
   }
 
   const body = await response.arrayBuffer();
-  return toPngResponse(body);
+  return toPngResponse(body, response.headers, response.status);
 };
 
 /**

--- a/src/lib/premadeOpenGraph.ts
+++ b/src/lib/premadeOpenGraph.ts
@@ -1,0 +1,54 @@
+import { loadFileOnEdge } from "@/lib/edge";
+
+const PNG_CONTENT_TYPE = "image/png";
+const DEFAULT_CACHE_CONTROL = "public, max-age=2678400, must-revalidate";
+
+type PremadeOpenGraphOptions = {
+  fallbackImagePath: string;
+  localeImageUrl?: string;
+};
+
+const toPngResponse = (
+  body: ArrayBuffer,
+  headers?: HeadersInit,
+  status = 200,
+): Response => {
+  const responseHeaders = new Headers(headers);
+
+  responseHeaders.set("Content-Type", PNG_CONTENT_TYPE);
+
+  if (!responseHeaders.get("Cache-Control")) {
+    responseHeaders.set("Cache-Control", DEFAULT_CACHE_CONTROL);
+  }
+
+  return new Response(body, {
+    status,
+    headers: responseHeaders,
+  });
+};
+
+const fetchPng = async (url: string): Promise<Response> => {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    return response;
+  }
+
+  const body = await response.arrayBuffer();
+  return toPngResponse(body, response.headers, response.status);
+};
+
+/**
+ * Returns a premade OG image while enforcing `image/png` content type.
+ */
+export const getPremadeOpenGraphResponse = async ({
+  fallbackImagePath,
+  localeImageUrl,
+}: PremadeOpenGraphOptions): Promise<Response> => {
+  if (localeImageUrl) {
+    return fetchPng(localeImageUrl);
+  }
+
+  const body = await loadFileOnEdge.asArrayBuffer(fallbackImagePath);
+  return toPngResponse(body);
+};

--- a/src/lib/premadeOpenGraph.ts
+++ b/src/lib/premadeOpenGraph.ts
@@ -13,10 +13,10 @@ const toPngResponse = (
 ): Response => {
   const responseHeaders = new Headers(headers);
 
-  responseHeaders.set("Content-Type", PNG_CONTENT_TYPE);
+  responseHeaders.set('Content-Type', PNG_CONTENT_TYPE);
 
-  if (!responseHeaders.get("Cache-Control")) {
-    responseHeaders.set("Cache-Control", DEFAULT_CACHE_CONTROL);
+  if (!responseHeaders.get('Cache-Control')) {
+    responseHeaders.set('Cache-Control', DEFAULT_CACHE_CONTROL);
   }
 
   return new Response(body, {

--- a/src/lib/premadeOpenGraph.ts
+++ b/src/lib/premadeOpenGraph.ts
@@ -1,10 +1,8 @@
-import { loadFileOnEdge } from "@/lib/edge";
-
-const PNG_CONTENT_TYPE = "image/png";
-const DEFAULT_CACHE_CONTROL = "public, max-age=2678400, must-revalidate";
+const PNG_CONTENT_TYPE = 'image/png';
+const DEFAULT_CACHE_CONTROL = 'public, max-age=2678400, must-revalidate';
 
 type PremadeOpenGraphOptions = {
-  fallbackImagePath: string;
+  fallbackImageUrl: URL;
   localeImageUrl?: string;
 };
 
@@ -38,17 +36,27 @@ const fetchPng = async (url: string): Promise<Response> => {
   return toPngResponse(body, response.headers, response.status);
 };
 
+const fetchFallbackPng = async (url: URL): Promise<Response> => {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    return response;
+  }
+
+  const body = await response.arrayBuffer();
+  return toPngResponse(body);
+};
+
 /**
  * Returns a premade OG image while enforcing `image/png` content type.
  */
 export const getPremadeOpenGraphResponse = async ({
-  fallbackImagePath,
+  fallbackImageUrl,
   localeImageUrl,
 }: PremadeOpenGraphOptions): Promise<Response> => {
   if (localeImageUrl) {
     return fetchPng(localeImageUrl);
   }
 
-  const body = await loadFileOnEdge.asArrayBuffer(fallbackImagePath);
-  return toPngResponse(body);
+  return fetchFallbackPng(fallbackImageUrl);
 };

--- a/src/pages/api/og/about-the-quran/index.tsx
+++ b/src/pages/api/og/about-the-quran/index.tsx
@@ -1,4 +1,5 @@
 import { parseRequest } from '@/lib/edge';
+import { getPremadeOpenGraphResponse } from '@/lib/premadeOpenGraph';
 import type { PageConfig } from 'next/types';
 import type { NextRequest } from 'next/server';
 
@@ -19,7 +20,8 @@ const preMadeLocales = {};
 export default async function handler(req: NextRequest): Promise<Response> {
   const { language } = parseRequest(req);
 
-  if (preMadeLocales[language.code]) return fetch(preMadeLocales[language.code]);
-
-  return fetch(new URL('/public/premade/og_about_en.png', import.meta.url),);
+  return getPremadeOpenGraphResponse({
+    localeImageUrl: preMadeLocales[language.code],
+    fallbackImagePath: '/premade/og_about_en.png',
+  });
 }

--- a/src/pages/api/og/about-the-quran/index.tsx
+++ b/src/pages/api/og/about-the-quran/index.tsx
@@ -22,6 +22,6 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   return getPremadeOpenGraphResponse({
     localeImageUrl: preMadeLocales[language.code],
-    fallbackImagePath: '/premade/og_about_en.png',
+    fallbackImageUrl: new URL('/public/premade/og_about_en.png', import.meta.url),
   });
 }

--- a/src/pages/api/og/beyond-ramadan/index.tsx
+++ b/src/pages/api/og/beyond-ramadan/index.tsx
@@ -22,6 +22,6 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   return getPremadeOpenGraphResponse({
     localeImageUrl: preMadeLocales[language.code],
-    fallbackImagePath: '/premade/og_beyond_ramadan.png',
+    fallbackImageUrl: new URL('/public/premade/og_beyond_ramadan.png', import.meta.url),
   });
 }

--- a/src/pages/api/og/beyond-ramadan/index.tsx
+++ b/src/pages/api/og/beyond-ramadan/index.tsx
@@ -1,4 +1,5 @@
 import { parseRequest } from '@/lib/edge';
+import { getPremadeOpenGraphResponse } from '@/lib/premadeOpenGraph';
 import type { PageConfig } from 'next/types';
 import type { NextRequest } from 'next/server';
 
@@ -19,7 +20,8 @@ const preMadeLocales = {};
 export default async function handler(req: NextRequest): Promise<Response> {
   const { language } = parseRequest(req);
 
-  if (preMadeLocales[language.code]) return fetch(preMadeLocales[language.code]);
-
-  return fetch(new URL('/public/premade/og_beyond_ramadan.png', import.meta.url),);
+  return getPremadeOpenGraphResponse({
+    localeImageUrl: preMadeLocales[language.code],
+    fallbackImagePath: '/premade/og_beyond_ramadan.png',
+  });
 }

--- a/src/pages/api/og/calendar/index.tsx
+++ b/src/pages/api/og/calendar/index.tsx
@@ -1,4 +1,5 @@
 import { parseRequest } from '@/lib/edge';
+import { getPremadeOpenGraphResponse } from '@/lib/premadeOpenGraph';
 import type { PageConfig } from 'next/types';
 import type { NextRequest } from 'next/server';
 
@@ -19,7 +20,8 @@ const preMadeLocales = {};
 export default async function handler(req: NextRequest): Promise<Response> {
   const { language } = parseRequest(req);
 
-  if (preMadeLocales[language.code]) return fetch(preMadeLocales[language.code]);
-
-  return fetch(new URL('/public/premade/og_calendar.png', import.meta.url),);
+  return getPremadeOpenGraphResponse({
+    localeImageUrl: preMadeLocales[language.code],
+    fallbackImagePath: '/premade/og_calendar.png',
+  });
 }

--- a/src/pages/api/og/calendar/index.tsx
+++ b/src/pages/api/og/calendar/index.tsx
@@ -22,6 +22,6 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   return getPremadeOpenGraphResponse({
     localeImageUrl: preMadeLocales[language.code],
-    fallbackImagePath: '/premade/og_calendar.png',
+    fallbackImageUrl: new URL('/public/premade/og_calendar.png', import.meta.url),
   });
 }

--- a/src/pages/api/og/embed/index.tsx
+++ b/src/pages/api/og/embed/index.tsx
@@ -20,6 +20,6 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   return getPremadeOpenGraphResponse({
     localeImageUrl: preMadeLocales[language.code],
-    fallbackImagePath: '/premade/og_embed.png',
+    fallbackImageUrl: new URL('/public/premade/og_embed.png', import.meta.url),
   });
 }

--- a/src/pages/api/og/embed/index.tsx
+++ b/src/pages/api/og/embed/index.tsx
@@ -1,4 +1,5 @@
 import { parseRequest } from '@/lib/edge';
+import { getPremadeOpenGraphResponse } from '@/lib/premadeOpenGraph';
 import type { PageConfig } from 'next/types';
 import type { NextRequest } from 'next/server';
 
@@ -17,9 +18,8 @@ const preMadeLocales = {};
 export default async function handler(req: NextRequest): Promise<Response> {
   const { language } = parseRequest(req);
 
-  if (preMadeLocales[language.code]) {
-    return fetch(preMadeLocales[language.code]);
-  }
-
-  return fetch(new URL('/public/premade/og_embed.png', import.meta.url));
+  return getPremadeOpenGraphResponse({
+    localeImageUrl: preMadeLocales[language.code],
+    fallbackImagePath: '/premade/og_embed.png',
+  });
 }

--- a/src/pages/api/og/explore-answers/index.tsx
+++ b/src/pages/api/og/explore-answers/index.tsx
@@ -1,4 +1,5 @@
 import { parseRequest } from '@/lib/edge';
+import { getPremadeOpenGraphResponse } from '@/lib/premadeOpenGraph';
 import type { PageConfig } from 'next/types';
 import type { NextRequest } from 'next/server';
 
@@ -19,9 +20,8 @@ const preMadeLocales = {};
 export default async function handler(req: NextRequest): Promise<Response> {
   const { language } = parseRequest(req);
 
-  if (preMadeLocales[language.code]) {
-    return fetch(preMadeLocales[language.code]);
-  }
-
-  return fetch(new URL('/public/premade/og_explore_answers.png', import.meta.url),);
+  return getPremadeOpenGraphResponse({
+    localeImageUrl: preMadeLocales[language.code],
+    fallbackImagePath: '/premade/og_explore_answers.png',
+  });
 }

--- a/src/pages/api/og/explore-answers/index.tsx
+++ b/src/pages/api/og/explore-answers/index.tsx
@@ -22,6 +22,6 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   return getPremadeOpenGraphResponse({
     localeImageUrl: preMadeLocales[language.code],
-    fallbackImagePath: '/premade/og_explore_answers.png',
+    fallbackImageUrl: new URL('/public/premade/og_explore_answers.png', import.meta.url),
   });
 }

--- a/src/pages/api/og/learning-plans/index.tsx
+++ b/src/pages/api/og/learning-plans/index.tsx
@@ -22,6 +22,6 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   return getPremadeOpenGraphResponse({
     localeImageUrl: preMadeLocales[language.code],
-    fallbackImagePath: '/premade/og_learning_plans.png',
+    fallbackImageUrl: new URL('/public/premade/og_learning_plans.png', import.meta.url),
   });
 }

--- a/src/pages/api/og/learning-plans/index.tsx
+++ b/src/pages/api/og/learning-plans/index.tsx
@@ -1,4 +1,5 @@
 import { parseRequest } from '@/lib/edge';
+import { getPremadeOpenGraphResponse } from '@/lib/premadeOpenGraph';
 import type { PageConfig } from 'next/types';
 import type { NextRequest } from 'next/server';
 
@@ -19,9 +20,8 @@ const preMadeLocales = {};
 export default async function handler(req: NextRequest): Promise<Response> {
   const { language } = parseRequest(req);
 
-  if (preMadeLocales[language.code]) {
-    return fetch(preMadeLocales[language.code]);
-  }
-
-  return fetch(new URL('/public/premade/og_learning_plans.png', import.meta.url),);
+  return getPremadeOpenGraphResponse({
+    localeImageUrl: preMadeLocales[language.code],
+    fallbackImagePath: '/premade/og_learning_plans.png',
+  });
 }

--- a/src/pages/api/og/media/index.tsx
+++ b/src/pages/api/og/media/index.tsx
@@ -1,4 +1,5 @@
 import { parseRequest } from '@/lib/edge';
+import { getPremadeOpenGraphResponse } from '@/lib/premadeOpenGraph';
 import type { PageConfig } from 'next/types';
 import type { NextRequest } from 'next/server';
 
@@ -19,9 +20,8 @@ const preMadeLocales = {};
 export default async function handler(req: NextRequest): Promise<Response> {
   const { language } = parseRequest(req);
 
-  if (preMadeLocales[language.code]) {
-    return fetch(preMadeLocales[language.code]);
-  }
-
-  return fetch(new URL('/public/premade/og_media.png', import.meta.url),);
+  return getPremadeOpenGraphResponse({
+    localeImageUrl: preMadeLocales[language.code],
+    fallbackImagePath: '/premade/og_media.png',
+  });
 }

--- a/src/pages/api/og/media/index.tsx
+++ b/src/pages/api/og/media/index.tsx
@@ -22,6 +22,6 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   return getPremadeOpenGraphResponse({
     localeImageUrl: preMadeLocales[language.code],
-    fallbackImagePath: '/premade/og_media.png',
+    fallbackImageUrl: new URL('/public/premade/og_media.png', import.meta.url),
   });
 }

--- a/src/pages/api/og/preparing-for-ramadan/index.tsx
+++ b/src/pages/api/og/preparing-for-ramadan/index.tsx
@@ -22,6 +22,6 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   return getPremadeOpenGraphResponse({
     localeImageUrl: preMadeLocales[language.code],
-    fallbackImagePath: '/premade/og_preparing_for_ramadan.png',
+    fallbackImageUrl: new URL('/public/premade/og_preparing_for_ramadan.png', import.meta.url),
   });
 }

--- a/src/pages/api/og/preparing-for-ramadan/index.tsx
+++ b/src/pages/api/og/preparing-for-ramadan/index.tsx
@@ -1,4 +1,5 @@
 import { parseRequest } from '@/lib/edge';
+import { getPremadeOpenGraphResponse } from '@/lib/premadeOpenGraph';
 import type { PageConfig } from 'next/types';
 import type { NextRequest } from 'next/server';
 
@@ -19,9 +20,8 @@ const preMadeLocales = {};
 export default async function handler(req: NextRequest): Promise<Response> {
   const { language } = parseRequest(req);
 
-  if (preMadeLocales[language.code]) {
-    return fetch(preMadeLocales[language.code]);
-  }
-
-  return fetch(new URL('/public/premade/og_preparing_for_ramadan.png', import.meta.url),);
+  return getPremadeOpenGraphResponse({
+    localeImageUrl: preMadeLocales[language.code],
+    fallbackImagePath: '/premade/og_preparing_for_ramadan.png',
+  });
 }

--- a/src/pages/api/og/ramadan2026/index.tsx
+++ b/src/pages/api/og/ramadan2026/index.tsx
@@ -1,4 +1,5 @@
 import { parseRequest } from '@/lib/edge';
+import { getPremadeOpenGraphResponse } from '@/lib/premadeOpenGraph';
 import type { PageConfig } from 'next/types';
 import type { NextRequest } from 'next/server';
 
@@ -17,9 +18,8 @@ const preMadeLocales: Record<string, string> = {};
 export default async function handler(req: NextRequest): Promise<Response> {
   const { language } = parseRequest(req);
 
-  if (preMadeLocales[language.code]) {
-    return fetch(preMadeLocales[language.code]);
-  }
-
-  return fetch(new URL('/public/premade/og_ramadan2026.png', import.meta.url));
+  return getPremadeOpenGraphResponse({
+    localeImageUrl: preMadeLocales[language.code],
+    fallbackImagePath: '/premade/og_ramadan2026.png',
+  });
 }

--- a/src/pages/api/og/ramadan2026/index.tsx
+++ b/src/pages/api/og/ramadan2026/index.tsx
@@ -20,6 +20,6 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   return getPremadeOpenGraphResponse({
     localeImageUrl: preMadeLocales[language.code],
-    fallbackImagePath: '/premade/og_ramadan2026.png',
+    fallbackImageUrl: new URL('/public/premade/og_ramadan2026.png', import.meta.url),
   });
 }

--- a/src/pages/api/og/ramadanchallenge/index.tsx
+++ b/src/pages/api/og/ramadanchallenge/index.tsx
@@ -1,4 +1,5 @@
 import { parseRequest } from '@/lib/edge';
+import { getPremadeOpenGraphResponse } from '@/lib/premadeOpenGraph';
 import type { PageConfig } from 'next/types';
 import type { NextRequest } from 'next/server';
 
@@ -17,9 +18,8 @@ const preMadeLocales: Record<string, string> = {};
 export default async function handler(req: NextRequest): Promise<Response> {
   const { language } = parseRequest(req);
 
-  if (preMadeLocales[language.code]) {
-    return fetch(preMadeLocales[language.code]);
-  }
-
-  return fetch(new URL('/public/premade/og_ramadanchallenge.png', import.meta.url));
+  return getPremadeOpenGraphResponse({
+    localeImageUrl: preMadeLocales[language.code],
+    fallbackImagePath: '/premade/og_ramadanchallenge.png',
+  });
 }

--- a/src/pages/api/og/ramadanchallenge/index.tsx
+++ b/src/pages/api/og/ramadanchallenge/index.tsx
@@ -20,6 +20,6 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   return getPremadeOpenGraphResponse({
     localeImageUrl: preMadeLocales[language.code],
-    fallbackImagePath: '/premade/og_ramadanchallenge.png',
+    fallbackImageUrl: new URL('/public/premade/og_ramadanchallenge.png', import.meta.url),
   });
 }

--- a/src/pages/api/og/what-is-ramadan/index.tsx
+++ b/src/pages/api/og/what-is-ramadan/index.tsx
@@ -22,6 +22,6 @@ export default async function handler(req: NextRequest): Promise<Response> {
 
   return getPremadeOpenGraphResponse({
     localeImageUrl: preMadeLocales[language.code],
-    fallbackImagePath: '/premade/og_what_is_ramadan.png',
+    fallbackImageUrl: new URL('/public/premade/og_what_is_ramadan.png', import.meta.url),
   });
 }

--- a/src/pages/api/og/what-is-ramadan/index.tsx
+++ b/src/pages/api/og/what-is-ramadan/index.tsx
@@ -1,4 +1,5 @@
 import { parseRequest } from '@/lib/edge';
+import { getPremadeOpenGraphResponse } from '@/lib/premadeOpenGraph';
 import type { PageConfig } from 'next/types';
 import type { NextRequest } from 'next/server';
 
@@ -19,9 +20,8 @@ const preMadeLocales = {};
 export default async function handler(req: NextRequest): Promise<Response> {
   const { language } = parseRequest(req);
 
-  if (preMadeLocales[language.code]) {
-    return fetch(preMadeLocales[language.code]);
-  }
-
-  return fetch(new URL('/public/premade/og_what_is_ramadan.png', import.meta.url),);
+  return getPremadeOpenGraphResponse({
+    localeImageUrl: preMadeLocales[language.code],
+    fallbackImagePath: '/premade/og_what_is_ramadan.png',
+  });
 }

--- a/tests/og-images.spec.ts
+++ b/tests/og-images.spec.ts
@@ -201,6 +201,23 @@ test.describe("Static Page OG Endpoints", () => {
 });
 
 // ============================================================================
+// STATIC PREMADE FALLBACK (PORT AGNOSTIC)
+// ============================================================================
+test.describe("Static Premade Fallback", () => {
+  test("ramadan2026 fallback works on non-default port", async ({
+    request,
+  }) => {
+    const response = await request.get("/api/og/ramadan2026?lang=en");
+    expect(response.status()).toBe(200);
+    expect(response.headers()["content-type"]).toContain("image/png");
+
+    const body = await response.body();
+    expect(isPng(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(1000);
+  });
+});
+
+// ============================================================================
 // ABOUT THE QURAN ENDPOINT
 // ============================================================================
 test.describe("About The Quran (/api/og/about-the-quran)", () => {

--- a/tests/og-images.spec.ts
+++ b/tests/og-images.spec.ts
@@ -28,6 +28,14 @@ const STATIC_PAGES = [
   "/api/og/what-is-ramadan",
 ];
 
+// All static OG pages that return premade assets.
+const STATIC_PREMADE_PAGES = [
+  ...STATIC_PAGES,
+  "/api/og/embed",
+  "/api/og/ramadan2026",
+  "/api/og/ramadanchallenge",
+];
+
 // Sample chapters (first, middle, last, popular ones)
 const SAMPLE_CHAPTERS = [1, 2, 18, 36, 55, 67, 78, 114];
 
@@ -129,7 +137,7 @@ test.describe("Chapter OG Endpoint (/api/og/chapter/[id])", () => {
     for (const { chapter, verse } of verseTests) {
       test(`chapter ${chapter} verse ${verse}`, async ({ request }) => {
         const response = await request.get(
-          `/api/og/chapter/${chapter}?verse=${verse}`
+          `/api/og/chapter/${chapter}?verse=${verse}`,
         );
         expect(response.status()).toBe(200);
 
@@ -160,12 +168,13 @@ test.describe("Chapter OG Endpoint (/api/og/chapter/[id])", () => {
 // STATIC PAGE ENDPOINTS
 // ============================================================================
 test.describe("Static Page OG Endpoints", () => {
-  for (const page of STATIC_PAGES) {
+  for (const page of STATIC_PREMADE_PAGES) {
     const pageName = page.split("/").pop();
 
     test(`${pageName} returns valid PNG`, async ({ request }) => {
       const response = await request.get(page);
       expect(response.status(), `Failed for ${page}`).toBe(200);
+      expect(response.headers()["content-type"]).toContain("image/png");
 
       const body = await response.body();
       expect(isPng(body), `Not a valid PNG for ${page}`).toBe(true);
@@ -175,13 +184,14 @@ test.describe("Static Page OG Endpoints", () => {
 
   // Test static pages with language parameter (if supported)
   test.describe("Static pages with language parameter", () => {
-    for (const page of STATIC_PAGES) {
+    for (const page of STATIC_PREMADE_PAGES) {
       const pageName = page.split("/").pop();
 
       test(`${pageName} with lang=ar`, async ({ request }) => {
         const response = await request.get(`${page}?lang=ar`);
         // Some static pages may not support lang param, so 200 is expected
         expect(response.status()).toBe(200);
+        expect(response.headers()["content-type"]).toContain("image/png");
 
         const body = await response.body();
         expect(isPng(body)).toBe(true);


### PR DESCRIPTION
## Summary
- add a shared premade OG helper to enforce `Content-Type: image/png` on static OG responses
- migrate static OG handlers to a shared response path while keeping fallback asset resolution host-independent
- avoid request-origin based URL construction (`req.url`) to keep behavior deterministic and avoid host-header coupling
- expand static OG Playwright checks to assert PNG MIME type for all premade static routes

## Why
Static OG endpoints were returning PNG bytes without `content-type` on production (`og.qurancdn.com`) for routes like:
- `/api/og/calendar`
- `/api/og/ramadan2026`
- `/api/og/what-is-ramadan`

Some social unfurlers require the correct MIME header and fail/skip preview generation when it is missing.

A review comment also identified a deployment portability issue: static fallbacks depended on `relativeUrl()` defaulting to `http://localhost:3000` when `VERCEL_URL` was unset, which can break non-default-port/self-hosted setups.

## Implementation Notes
- New helper: `src/lib/premadeOpenGraph.ts`
  - preserves upstream status/body for locale URLs
  - enforces `Content-Type: image/png`
  - sets default cache-control (`public, max-age=2678400, must-revalidate`) when missing
- Static OG handlers now call `getPremadeOpenGraphResponse(...)`
- Fallback asset loading now uses route-local `new URL('/public/premade/...', import.meta.url)` and passes that URL into the helper, removing `loadFileOnEdge -> relativeUrl()` dependency for these static routes

## Validation
- red/green regression on non-default port fallback:
  - failing before fix (with app on `:4000` and no listener on `:3000`): `BASE_URL=http://localhost:4000 corepack yarn playwright test tests/og-images.spec.ts -g "ramadan2026 fallback works on non-default port" --project=chromium`
  - passing after fix: same command
- static premade coverage on non-default port:
  - `BASE_URL=http://localhost:4000 corepack yarn playwright test tests/og-images.spec.ts -g "Static Page OG Endpoints|Static Premade Fallback" --project=chromium`
  - result: `23 passed`

## Security
- does not use `new URL('/premade/...', req.url)`
- avoids host-derived origin behavior raised in prior review comments
