### PR TITLE
og,sentry: capture internal fetch failures in /api/og routes

### DIFF
--- a/src/lib/edge.ts
+++ b/src/lib/edge.ts
@@ -80,12 +80,32 @@ export const fetchWithEdgeSentry = async (
   url: string | URL,
   context?: EdgeExceptionContext,
 ) => {
+  let response: Response;
+
   try {
-    return await fetch(url);
+    response = await fetch(url);
   } catch (error) {
     await captureEdgeException(error, context);
     throw error;
   }
+
+  if (!response.ok) {
+    const fetchUrl = typeof url === 'string' ? url : url.toString();
+    const error = new Error(
+      `Fetch failed with status ${response.status} ${response.statusText} for ${fetchUrl}`,
+    );
+
+    await captureEdgeException(error, {
+      ...context,
+      fetch_url: fetchUrl,
+      fetch_status: response.status,
+      fetch_status_text: response.statusText,
+    });
+
+    throw error;
+  }
+
+  return response;
 };
 
 const relativeUrl = (url: string) => {

--- a/src/lib/edge.ts
+++ b/src/lib/edge.ts
@@ -21,6 +21,11 @@ type ParsedRequest = {
   searchParams: URLSearchParams;
 };
 
+type EdgeExceptionContext = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
 /**
  *  Parse request object
  *
@@ -48,6 +53,39 @@ export const parseRequest = (req: NextRequest): ParsedRequest => {
 export const getEdgeBaseUrl = () => {
   const port = process.env.PORT || '3000';
   return `http://127.0.0.1:${port}`;
+};
+
+const captureEdgeException = async (
+  error: unknown,
+  context?: EdgeExceptionContext,
+) => {
+  const Sentry = await import('@sentry/nextjs');
+
+  Sentry.withScope(scope => {
+    if (context) {
+      Object.entries(context).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          scope.setExtra(key, value);
+        }
+      });
+    }
+
+    Sentry.captureException(error);
+  });
+
+  await Sentry.flush(2000).catch(() => undefined);
+};
+
+export const fetchWithEdgeSentry = async (
+  url: string | URL,
+  context?: EdgeExceptionContext,
+) => {
+  try {
+    return await fetch(url);
+  } catch (error) {
+    await captureEdgeException(error, context);
+    throw error;
+  }
 };
 
 const relativeUrl = (url: string) => {

--- a/src/pages/api/og/chapter/[id].tsx
+++ b/src/pages/api/og/chapter/[id].tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from '@vercel/og';
 import type { NextRequest } from 'next/server';
 import type { PageConfig } from 'next/types';
 import ChapterOpenGraph from '@/components/OpenGraph/Chapter';
-import { getEdgeBaseUrl, json, parseRequest } from '@/lib/edge';
+import { fetchWithEdgeSentry, getEdgeBaseUrl, json, parseRequest } from '@/lib/edge';
 import { loadOpenGraphBackground } from '@/lib/og';
 import { isValidChapterId, isValidVerseNumber } from '@/lib/validator';
 import bengali from '@/lib/fonts/bengali';
@@ -32,7 +32,11 @@ export default async function handler(req: NextRequest) {
 
   const edgeBaseUrl = getEdgeBaseUrl();
   const [{ chapter }, bgSrc, surahFontData, mainFontData] = await Promise.all([
-    fetch(`${edgeBaseUrl}/data/${language.code}/${chapterId}.json`).then(
+    fetchWithEdgeSentry(`${edgeBaseUrl}/data/${language.code}/${chapterId}.json`, {
+      route: '/api/og/chapter/[id]',
+      chapter_id: chapterId,
+      language: language.code,
+    }).then(
       res => res.json() as Promise<ChapterResponse>,
     ),
     loadOpenGraphBackground(),

--- a/src/pages/api/og/index.tsx
+++ b/src/pages/api/og/index.tsx
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import type { PageConfig } from "next/types";
-import { getEdgeBaseUrl } from '@/lib/edge';
+import { fetchWithEdgeSentry, getEdgeBaseUrl } from '@/lib/edge';
 
 export const config: PageConfig = {
     runtime: "edge",
@@ -27,5 +27,10 @@ export default async function handler(req: NextRequest) {
     const file = LANG_TO_FILE[lang] || LANG_TO_FILE.en;
 
     const assetUrl = new URL(`/premade/${file}`, getEdgeBaseUrl());
-    return fetch(assetUrl);
+    return fetchWithEdgeSentry(assetUrl, {
+        route: "/api/og",
+        lang,
+        file,
+        asset_url: assetUrl.toString(),
+    });
 }


### PR DESCRIPTION
## Summary
- add `fetchWithEdgeSentry` helper to capture and flush Sentry exceptions for failed internal fetches
- instrument `/api/og` premade image fetch with request context
- instrument `/api/og/chapter/[id]` chapter JSON fetch with route/chapter/language context

## Validation
- `pnpm exec tsc --noEmit`